### PR TITLE
Add minimal meta.yml file and generated README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Reduction Effects
+
+[![Travis][travis-shield]][travis-link]
+[![Contributing][contributing-shield]][contributing-link]
+[![Code of Conduct][conduct-shield]][conduct-link]
+[![Gitter][gitter-shield]][gitter-link]
+
+[travis-shield]: https://travis-ci.com/coq-community/reduction-effects.svg?branch=master
+[travis-link]: https://travis-ci.com/coq-community/reduction-effects/builds
+
+[contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
+[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+
+[conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
+[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+
+[gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
+[gitter-link]: https://gitter.im/coq-community/Lobby
+
+
+
+
+
+## Meta
+
+- Author(s):
+  - Hugo Herbelin (initial)
+- Coq-community maintainer(s):
+  - Yishuai Li ([**@liyishuai**](https://github.com/liyishuai))
+  - Jason Gross ([**@JasonGross**](https://github.com/JasonGross))
+- License: [GNU Lesser General Public License v2.1](LICENSE)
+- Compatible Coq versions: Coq versions 8.7 to 8.8
+- Compatible OCaml versions: all versions supported by Coq
+- Additional Coq dependencies: none
+
+## Building and installation instructions
+
+The easiest way to install the latest released version of Reduction Effects
+is via [OPAM](https://opam.ocaml.org/doc/Install.html):
+
+```shell
+opam repo add coq-released https://coq.inria.fr/opam/released
+opam install coq-reduction-effects
+```
+
+To instead build and install manually, do:
+
+``` shell
+git clone https://github.com/coq-community/reduction-effects
+cd reduction-effects
+make   # or make -j <number-of-cores-on-your-machine>
+make install
+```
+
+After installation, the included modules are available under
+the `ReductionEffect` namespace.
+
+
+

--- a/meta.yml
+++ b/meta.yml
@@ -1,0 +1,32 @@
+---
+fullname: Reduction Effects
+shortname: reduction-effects
+organization: coq-community
+community: true
+
+synopsis: A Coq plugin to add reduction side effects to some Coq reduction strategies
+
+authors:
+- name: Hugo Herbelin
+  initial: true
+
+maintainers:
+- name: Yishuai Li
+  nickname: liyishuai
+- name: Jason Gross
+  nickname: JasonGross
+
+opam-file-maintainer: "Yishuai Li <yishuai@cis.upenn.edu>"
+
+license:
+  fullname: GNU Lesser General Public License v2.1
+  identifier: LGPL-2.1
+
+plugin: true
+
+supported_coq_versions:
+  text: Coq versions 8.7 to 8.8
+  opam: '{ >= "8.7" < "8.9~" }'
+
+
+namespace: ReductionEffect


### PR DESCRIPTION
This reuses the template from https://github.com/coq-community/manifesto/tree/master/templates to generate the README from a minimal `meta.yml` file. Note that you also have templates in there to generate an opam file (with slight differences from the one you added) and a `.travis.yml` which allows to test a Coq project using either opam or Nix without having to rebuild Coq.

The Travis badge is showing "build: unknown" because Travis hasn't figured yet the transfer of the repository.